### PR TITLE
Support CSV upload during aircraft creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 Open http://127.0.0.1:8000
+
+## CSV import on aircraft creation
+
+`POST /aircraft` now accepts an optional CSV file using multipart form data. Example:
+
+```bash
+curl -F "name=My Plane" \
+     -F "model=C-172" \
+     -F "csv_file=@items.csv" \
+     http://127.0.0.1:8000/aircraft
+```
+
+The part named `csv_file` must contain a CSV with the columns used by the importer, such as `Item Code`, `Position`, `Description`, `Type`, `Interval Months`, `Interval Hours`, `Interval Landings`, `Adjusted Interval`, `Part Number`, `Part Serial`, `Last Completed Date`, `Last Completed Hours`, `Last Completed Landings`, `Last Completed City`, `Due Next Date`, `Due Next Hours`, `Due Next Landings`, `Time Remaining`, `Hours Remaining`, `Landings Remaining`, `Status` and `Status Note`.
+
+When provided, the endpoint creates the aircraft and immediately loads the CSV rows. The response includes both the aircraft data and the import result (`import_batch_id`, inserted rows, errors, etc.).


### PR DESCRIPTION
## Summary
- Allow `POST /aircraft` to accept an optional `csv_file` and import its contents
- Document multipart CSV import usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2ed4f73d48323beab1cd5510b403f